### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ exports.load_config = function () {
   // active zones
   if (this.cfg.main.periodic_checks < 5) {
     // all configured are enabled
-    this.zones = new Set(...this.cfg.main.zones)
+    // The original code is making a Set from the already existing Set created above. It leads to gibberish
+    //this.zones = new Set(...this.cfg.main.zones)
+    this.zones = this.cfg.main.zones
   } else {
     this.zones = new Set() // populated by check_zones()
   }


### PR DESCRIPTION
Changes proposed in this pull request:

zones isn't parsed properly because it creates a Set from a Set. It leads to this sort of situation:

this.cfg.main.zones (array ) [ 'zen.spamhaus.org', 'bl.spamcop.net', 'dnsbl.local.com' ]
this.cfg.main.zones (Set) Set(3) { 'zen.spamhaus.org', 'bl.spamcop.net', 'dnsbl.local.com' }
this.zones (Set) (Set) 

@4000000066c7ffc302a8debc Set(13) {
@4000000066c7ffc302a8e2a4   'z',
@4000000066c7ffc302a8e2a4   'e',
@4000000066c7ffc302a8e2a4   'n',
@4000000066c7ffc302a8e2a4   '.',
@4000000066c7ffc302a8e2a4   's',
@4000000066c7ffc302a8e68c   'p',
@4000000066c7ffc302a8e68c   'a',
@4000000066c7ffc302a8e68c   'm',
@4000000066c7ffc302a8e68c   'h',
@4000000066c7ffc302a8e68c   'u',
@4000000066c7ffc302a8e68c   'o',
@4000000066c7ffc302a8e68c   'r',
@4000000066c7ffc302a8e68c   'g'
@4000000066c7ffc302a8e68c }