### PR TITLE
Fix crash when zone specific config is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix: don't crash when zone settings is missing
+
 ### [1.2.1] - 2024-08-22
 
 - fix: don't make a set from a set (happened when periodic_checks < 5), #9

--- a/index.js
+++ b/index.js
@@ -344,7 +344,7 @@ exports.checkZoneNegative = async function (zone, ip) {
   // IPv4-based DNSxLs MUST NOT contain an entry for 127.0.0.1.
 
   // skip this test for DNS lists that don't follow the RFC
-  if (this.cfg[zone].loopback_is_rejected) return true
+  if (this.cfg[zone]?.loopback_is_rejected) return true
 
   const query = ipQuery(ip, zone)
   try {
@@ -373,7 +373,7 @@ exports.check_zone = async function (zone) {
 
   this.enable_zone(zone) // both tests passed
 
-  if (this.cfg[zone].ipv6 === true) {
+  if (this.cfg[zone]?.ipv6 === true) {
     await this.checkZonePositive(zone, '::FFFF:7F00:2')
     await this.checkZoneNegative(zone, '::FFFF:7F00:1')
   }


### PR DESCRIPTION
Changes proposed in this pull request:

- Zone specific settings are optional, so check if it exists before accessing properties inside it

Checklist:

- [ ] docs updated
- [ ] tests updated
- [X] Changes.md updated
- [ ] package.json.version bumped

Was reported in our forum at https://forum.cloudron.io/topic/13029/haraka-mailserver-logs-show-loopback_is_rejected-errors/ (has a backtrace)