### PR TITLE
Removed SORBS.net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
+- removed SORBS.net
 
 ### [1.2.3] - 2025-01-26
 

--- a/config/dns-list.ini
+++ b/config/dns-list.ini
@@ -12,7 +12,6 @@ zones[]=psbl.surriel.com
 zones[]=bl.spamcop.net
 zones[]=dnsbl-1.uceprotect.net
 zones[]=zen.spamhaus.org
-zones[]=dnsbl.sorbs.net
 zones[]=dnsbl.justspam.org
 zones[]=list.dnswl.org
 zones[]=hostkarma.junkemailfilter.com
@@ -68,8 +67,6 @@ ipv6=false
 ipv6=true
 
 [dnsbl-1.uceprotect.net]
-
-[dnsbl.sorbs.net]
 
 [dnsbl.justspam.org]
 


### PR DESCRIPTION
It seems that SORBS.net is now closed, see https://sorbs.net/

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [ ] package.json.version bumped
